### PR TITLE
Support passing params when connecting

### DIFF
--- a/packages/js/src/__tests__/lib/bearer.test.ts
+++ b/packages/js/src/__tests__/lib/bearer.test.ts
@@ -1,7 +1,8 @@
 import Bearer, { findElements, calculateModalPosition } from '../../lib/bearer'
 import { IntegrationClient } from '../../lib/integrationClient'
 
-const clientId = 'a-client-id'
+const clientId = 'client-id'
+const setupId = 'test-setup-id'
 
 describe('bearer', () => {
   it('exports a Bearer class', () => {
@@ -86,7 +87,7 @@ describe('bearer', () => {
   })
 
   describe('connect', () => {
-    const instance = new Bearer('client-id')
+    const instance = new Bearer(clientId)
     const openSpy = jest.fn()
     window.open = openSpy
 
@@ -102,6 +103,16 @@ describe('bearer', () => {
         '',
         // jsdom has no easy to configure jsdom screen size, unit tests are covering calculateModalPosition
         'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=0, height=0, top=0, left=0'
+      )
+    })
+
+    it('includes any connect parameters in the URL', () => {
+      instance.connect('my-integration', setupId, { params: { x: 123, y: 'hello' } })
+
+      expect(openSpy).toHaveBeenCalledWith(
+        `INTEGRATION_HOST_URL/v2/auth/my-integration?params%5Bx%5D=123&params%5By%5D=hello&setupId=${setupId}&clientId=${clientId}`,
+        '',
+        expect.anything()
       )
     })
 

--- a/packages/js/src/__tests__/lib/utils.test.ts
+++ b/packages/js/src/__tests__/lib/utils.test.ts
@@ -32,7 +32,7 @@ describe('buildQuery', () => {
     }
 
     expect(buildQuery(params)).toMatchInlineSnapshot(
-      `"falseParams=false&aString=ok%20with%20space%20and%20accents%20%C3%A9%C3%A9%C3%A0&aNumber=1&nested%5Bx%5D=1&nested%5By%5D=2&nested%5Bz%5D%5Ba%5D=hello"`
+      `"falseParams=false&aString=ok+with+space+and+accents+%C3%A9%C3%A9%C3%A0&aNumber=1&nested%5Bx%5D=1&nested%5By%5D=2&nested%5Bz%5D%5Ba%5D=hello"`
     )
   })
 

--- a/packages/js/src/__tests__/lib/utils.test.ts
+++ b/packages/js/src/__tests__/lib/utils.test.ts
@@ -1,18 +1,4 @@
-import { cleanQuery, buildQuery, cleanOptions } from '../../lib/utils'
-
-describe('cleanQuery', () => {
-  it('filters empty params and returns a string', () => {
-    const params = {
-      aNullParams: null,
-      undefinedParams: undefined,
-      falseParams: false,
-      aString: 'ok',
-      aNumber: 1
-    }
-
-    expect(cleanQuery(params)).toEqual({ aString: 'ok', aNumber: 1 })
-  })
-})
+import { buildQuery, cleanOptions } from '../../lib/utils'
 
 describe('cleanOptions', () => {
   it('removes keys with undefined valued', () => {
@@ -37,17 +23,36 @@ describe('buildQuery', () => {
       undefinedParams: undefined,
       falseParams: false,
       aString: 'ok with space and accents ééà',
-      aNumber: 1
+      aNumber: 1,
+      nested: {
+        x: 1,
+        y: 2,
+        z: { a: 'hello' }
+      }
     }
 
-    expect(buildQuery(params)).toEqual(
-      'aNullParams=null&undefinedParams=undefined&falseParams=false&aString=ok%20with%20space%20and%20accents%20%C3%A9%C3%A9%C3%A0&aNumber=1'
+    expect(buildQuery(params)).toMatchInlineSnapshot(
+      `"falseParams=false&aString=ok%20with%20space%20and%20accents%20%C3%A9%C3%A9%C3%A0&aNumber=1&nested%5Bx%5D=1&nested%5By%5D=2&nested%5Bz%5D%5Ba%5D=hello"`
     )
   })
 
-  it('returns and empty string', () => {
+  it('returns an empty string when there are no params', () => {
     const params = {}
 
     expect(buildQuery(params)).toEqual('')
+  })
+
+  it('filters empty params', () => {
+    const params = {
+      nullParam: null,
+      undefinedParam: undefined,
+      nested: {
+        nullParam: null,
+        undefinedParam: undefined
+      },
+      present: 'ok'
+    }
+
+    expect(buildQuery(params)).toEqual('present=ok')
   })
 })

--- a/packages/js/src/lib/bearer.ts
+++ b/packages/js/src/lib/bearer.ts
@@ -3,7 +3,7 @@ import debounce from 'debounce'
 import postRobot from 'post-robot'
 import { TIntegration } from './types'
 import debug from './logger'
-import { buildQuery, cleanQuery, cleanOptions } from './utils'
+import { buildQuery, cleanOptions } from './utils'
 import { EventEmitter } from './event'
 import { IntegrationClient } from './integrationClient'
 
@@ -62,16 +62,15 @@ export class Bearer {
   connect = (
     integration: string,
     setupId?: string,
-    { authId, width = 500, height = 600 }: { authId?: string; width?: number; height?: number } = {}
+    { authId, width = 500, height = 600, params = {} }: ConnectOptions = {}
   ) => {
-    const query = buildQuery(
-      cleanQuery({
-        setupId,
-        authId,
-        secured: this.config.secured,
-        clientId: this.clientId
-      })
-    )
+    const query = buildQuery({
+      params,
+      setupId,
+      authId,
+      secured: this.config.secured,
+      clientId: this.clientId
+    })
     const AUTHORIZED_URL = `${this.config.integrationHost}/v2/auth/${integration}?${query}`
 
     const promise = new Promise<{ integration: string; authId: string }>((resolve, reject) => {
@@ -233,6 +232,13 @@ export type TBearerOptions = {
   domObserver: boolean
   integrationHost: string
   refreshDebounceDelay: number
+}
+
+export interface ConnectOptions {
+  authId?: string
+  width?: number
+  height?: number
+  params?: Record<string, string | number>
 }
 
 /**

--- a/packages/js/src/lib/utils.ts
+++ b/packages/js/src/lib/utils.ts
@@ -1,20 +1,4 @@
 /**
- * cleanQuery
- * @param params {object} remove all falsy values
- */
-export function cleanQuery(params: Record<string, any>) {
-  return Object.keys(params).reduce(
-    (acc, key) => {
-      if (params[key]) {
-        acc[key] = params[key]
-      }
-      return acc
-    },
-    {} as Record<string, string>
-  )
-}
-
-/**
  * cleanOptions remove all undefined keys
  * @param obj {object}
  */
@@ -36,11 +20,19 @@ export function cleanOptions(obj: Record<string, any>) {
  */
 
 export function buildQuery(params: Record<string, any>) {
-  function encode(k: string) {
-    return encodeURIComponent(k) + '=' + encodeURIComponent(params[k])
+  function encode(key: string, value: any): string[] {
+    if (value === null || value === undefined) {
+      return []
+    }
+
+    if (typeof value === 'object') {
+      return flatMap(Object.keys(value), nestedKey => encode(`${key}[${nestedKey}]`, value[nestedKey]))
+    }
+
+    return [encodeURIComponent(key) + '=' + encodeURIComponent(value)]
   }
 
-  return Object.keys(params)
-    .map(encode)
-    .join('&')
+  return flatMap(Object.keys(params), key => encode(key, params[key])).join('&')
 }
+
+const flatMap = <T, U>(items: T[], f: (item: T) => U[]): U[] => ([] as U[]).concat(...items.map(f))

--- a/packages/js/src/lib/utils.ts
+++ b/packages/js/src/lib/utils.ts
@@ -20,19 +20,23 @@ export function cleanOptions(obj: Record<string, any>) {
  */
 
 export function buildQuery(params: Record<string, any>) {
-  function encode(key: string, value: any): string[] {
+  const searchParams = new URLSearchParams()
+
+  function addParams(key: string, value: any): void {
     if (value === null || value === undefined) {
-      return []
+      return
     }
 
     if (typeof value === 'object') {
-      return flatMap(Object.keys(value), nestedKey => encode(`${key}[${nestedKey}]`, value[nestedKey]))
+      return Object.keys(value).forEach(nestedKey => addParams(`${key}[${nestedKey}]`, value[nestedKey]))
     }
 
-    return [encodeURIComponent(key) + '=' + encodeURIComponent(value)]
+    searchParams.append(key, value)
   }
 
-  return flatMap(Object.keys(params), key => encode(key, params[key])).join('&')
-}
+  for (const key of Object.keys(params)) {
+    addParams(key, params[key])
+  }
 
-const flatMap = <T, U>(items: T[], f: (item: T) => U[]): U[] => ([] as U[]).concat(...items.map(f))
+  return searchParams.toString()
+}

--- a/packages/react/src/Connect.test.tsx
+++ b/packages/react/src/Connect.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { render, fireEvent, waitForElement } from '@testing-library/react'
 
 const integration = 'my-dummy-integration'
+const params = { someParam: 'some-param', otherParam: 'other-param' }
+
 const connect = jest.fn((_one, _two, { authId }) => {
   if (authId === 'failure') {
     return Promise.reject({ integration, authId })
@@ -29,7 +31,7 @@ describe('Connect', () => {
       expect(getByText('Click')).not.toBeNull()
       fireEvent.click(getByText(/Click/i))
 
-      expect(connect).toHaveBeenCalledWith(integration, 'my-setup', { authId: 'auth-id' })
+      expect(connect).toHaveBeenCalledWith(integration, 'my-setup', { params, authId: 'auth-id' })
       // next tick
       await waitForElement(() => getByText(/Click/i))
       expect(success).toHaveBeenCalledWith({ authId: 'auth-id', integration: 'my-dummy-integration' })
@@ -46,7 +48,7 @@ describe('Connect', () => {
       expect(getByText('Click')).not.toBeNull()
       fireEvent.click(getByText(/Click/i))
 
-      expect(connect).toHaveBeenCalledWith('dummy', 'my-setup', { authId: 'failure' })
+      expect(connect).toHaveBeenCalledWith('dummy', 'my-setup', { params, authId: 'failure' })
 
       await waitForElement(() => getByText(/Failure retry/i))
 
@@ -74,6 +76,7 @@ function renderConnect({
       onSuccess={success}
       onError={onError}
       authId={authId}
+      params={params}
       render={({ connect, error }) =>
         !error ? <button onClick={connect}>Click</button> : <button onClick={connect}>Failure retry</button>
       }

--- a/packages/react/src/Connect.tsx
+++ b/packages/react/src/Connect.tsx
@@ -8,6 +8,7 @@ export interface IConnectProps {
   integration: string
   authId?: string
   setupId?: string
+  params?: Record<string, string | number>
   onSuccess: (data: TAuthPayload) => void
   onError?: (data: { authId?: string; integration: string; error: Error }) => void
   render: (props: { loading: boolean; connect: () => void; error: any }) => JSX.Element
@@ -32,7 +33,7 @@ class Connect extends React.Component<IConnectProps, { error?: any }> {
     return () => {
       this.setError(null)
       bearer
-        .connect(this.props.integration, this.props.setupId, { authId: this.props.authId })
+        .connect(this.props.integration, this.props.setupId, { authId: this.props.authId, params: this.props.params })
         .then((data: TAuthPayload) => {
           if (this.props.integration === data.integration) {
             this.props.onSuccess(data)


### PR DESCRIPTION

## 🐻 What your PR is doing?

Adds support for a `params` property to the Connect Component. The params are passed to the JS client which sends them to the connect URL. The parameters can then be used in the auth/request config for an API.

## 📦 Package concerned

- @bearer/js
- @bearer/react

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
