### PR TITLE
Docs/outdated readme

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -66,14 +66,7 @@ const bearer = require('@bearer/node')
 
 const client = bearer(process.env.BEARER_SECRET_KEY, { httpClientSettings: { timeout: 10 * 1000 } }) // sets the timeout to 10 seconds
 const github = client.integration('INTEGRATION_ID', { httpClientSettings: { timeout: 1 } }) // sets the timeout to 1 second for this specific integration
-
-github
-  .invoke('myFunction')
-  .then(console.log)
-  .catch(console.error)
 ```
-
-[Learn more](https://docs.bearer.sh/working-with-bearer/manipulating-apis) on how to use custom functions with Bearer.sh.
 
 ## Notes
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -72,4 +72,4 @@ const github = client.integration('INTEGRATION_ID', { httpClientSettings: { time
 
 _Note 1_: we are using [axios](https://github.com/axios/axios) as the http client. Each `.get()`, `.post()`, `.put()`, ... or `.invoke()` returns an Axios Promise.
 
-_Note 2_: If you are using ExpressJS, have a look at the [@bearer/express](https://github.com/Bearer/bearer/tree/master/packages/express) client
+_Note 2_: If you are using ExpressJS, have a look at the [@bearer/express](https://github.com/Bearer/bearer-js/tree/master/packages/express) client


### PR DESCRIPTION
<!-- Feel free to remove any section you don't need -->

## 🐻 What your PR is doing?

Fixes a few problems with the node package readme.
- Link to @bearer/express pointed to an outdated git link
- Docs for the `invoke` method appear to be left over from it's removal in c81f6376c0d3f1a89cb2260d371b035f93b1e50d. Removed references from the timeout section.

## 📦 Package concerned

- @bearer/node

## 🖥 Screenshots or screen recording

<!-- record terminal (macOS) https://github.com/asciinema/asciinema -->

<!-- Before your changes -->
![image](https://user-images.githubusercontent.com/1649672/69113550-285f4500-0a38-11ea-9f2e-6fdaaef4e7e3.png)

**Before**

<!-- After your changes -->
![image](https://user-images.githubusercontent.com/1649672/69113572-390fbb00-0a38-11ea-8667-5980d3db3d33.png)


**After**

## 🐺 Links

<!--  Add any useful links, JIRA links, docs etc... -->

## 🛠 How to test it

<!-- Provide any helpful information to help reviewer test you changes -->

## ✅ Checklist

- [ ] Tests were added (if necessary)
- [x] I used conventional commits
