### PR TITLE
Add support for fetching auth details to Node client

### DIFF
--- a/packages/node/src/__snapshots__/client.test.ts.snap
+++ b/packages/node/src/__snapshots__/client.test.ts.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bearer client #integration getAuth OAuth 1 fetches the auth details and translates them to a friendly format 1`] = `
+Object {
+  "accessToken": TokenData {
+    "active": true,
+    "clientID": "test-consumer-key",
+    "expiresAt": undefined,
+    "issuedAt": 2019-11-18T14:27:45.000Z,
+    "scopes": undefined,
+    "tokenType": "oauth",
+    "value": "test-token",
+  },
+  "callbackParams": Object {
+    "oauth_token": "test-token",
+    "oauth_verifier": "test-verifier",
+  },
+  "consumerKey": "test-consumer-key",
+  "consumerSecret": "test-secret",
+  "rawData": Object {
+    "accessToken": Object {
+      "active": true,
+      "client_id": "test-consumer-key",
+      "iat": 1574087265,
+      "token_type": "oauth",
+      "value": "test-token",
+    },
+    "callbackParams": Object {
+      "oauth_token": "test-token",
+      "oauth_verifier": "test-verifier",
+    },
+    "consumerKey": "test-consumer-key",
+    "consumerSecret": "test-secret",
+    "signatureMethod": "HMAC-SHA1",
+    "tokenSecret": "test-token-secret",
+  },
+  "signatureMethod": "HMAC-SHA1",
+  "tokenSecret": "test-token-secret",
+}
+`;
+
+exports[`Bearer client #integration getAuth OAuth 2 fetches the auth details and translates them to a friendly format 1`] = `
+Object {
+  "accessToken": TokenData {
+    "active": true,
+    "clientID": "test-client-id",
+    "expiresAt": 2019-11-13T17:10:39.000Z,
+    "issuedAt": 2019-11-13T16:10:39.000Z,
+    "scopes": Array [
+      "read",
+      "write",
+    ],
+    "tokenType": "bearer",
+    "value": "test-access-token",
+  },
+  "callbackParams": Object {
+    "code": "test-code",
+  },
+  "clientID": "test-client-id",
+  "clientSecret": "test-secret",
+  "idToken": TokenData {
+    "active": true,
+    "clientID": "test-client-id",
+    "expiresAt": undefined,
+    "issuedAt": 2019-11-13T16:10:39.000Z,
+    "scopes": undefined,
+    "tokenType": "id",
+    "value": "test-id-token",
+  },
+  "idTokenJwt": Object {
+    "some": "id-data",
+  },
+  "rawData": Object {
+    "accessToken": Object {
+      "active": true,
+      "client_id": "test-client-id",
+      "exp": 1573665039,
+      "iat": 1573661439,
+      "scope": "read write",
+      "token_type": "bearer",
+      "value": "test-access-token",
+    },
+    "callbackParams": Object {
+      "code": "test-code",
+    },
+    "clientID": "test-client-id",
+    "clientSecret": "test-secret",
+    "idToken": Object {
+      "active": true,
+      "client_id": "test-client-id",
+      "iat": 1573661439,
+      "token_type": "id",
+      "value": "test-id-token",
+    },
+    "idTokenJwt": Object {
+      "some": "id-data",
+    },
+    "refreshToken": Object {
+      "active": true,
+      "client_id": "test-client-id",
+      "iat": 1573661439,
+      "scope": "read write",
+      "token_type": "refresh",
+      "value": "test-refresh-token",
+    },
+    "tokenResponse": Object {
+      "body": Object {
+        "access_token": "test-access-token",
+      },
+      "headers": Object {
+        "content-type": "application/json",
+      },
+    },
+  },
+  "refreshToken": TokenData {
+    "active": true,
+    "clientID": "test-client-id",
+    "expiresAt": undefined,
+    "issuedAt": 2019-11-13T16:10:39.000Z,
+    "scopes": Array [
+      "read",
+      "write",
+    ],
+    "tokenType": "refresh",
+    "value": "test-refresh-token",
+  },
+  "tokenResponse": Object {
+    "body": Object {
+      "access_token": "test-access-token",
+    },
+    "headers": Object {
+      "content-type": "application/json",
+    },
+  },
+}
+`;
+
+exports[`Bearer client #integration getAuth OAuth 2 works when optional values are missing 1`] = `
+Object {
+  "accessToken": TokenData {
+    "active": true,
+    "clientID": "test-client-id",
+    "expiresAt": undefined,
+    "issuedAt": 2019-11-13T16:10:39.000Z,
+    "scopes": Array [],
+    "tokenType": "bearer",
+    "value": "test-access-token",
+  },
+  "callbackParams": Object {
+    "code": "test-code",
+  },
+  "clientID": "test-client-id",
+  "clientSecret": "test-secret",
+  "rawData": Object {
+    "accessToken": Object {
+      "active": true,
+      "client_id": "test-client-id",
+      "iat": 1573661439,
+      "token_type": "bearer",
+      "value": "test-access-token",
+    },
+    "callbackParams": Object {
+      "code": "test-code",
+    },
+    "clientID": "test-client-id",
+    "clientSecret": "test-secret",
+    "tokenResponse": Object {
+      "body": Object {
+        "access_token": "test-access-token",
+      },
+      "headers": Object {
+        "content-type": "application/json",
+      },
+    },
+  },
+  "tokenResponse": Object {
+    "body": Object {
+      "access_token": "test-access-token",
+    },
+    "headers": Object {
+      "content-type": "application/json",
+    },
+  },
+}
+`;
+
+exports[`Bearer client #integration getAuth raises an error when there is no auth id set 1`] = `[Error: No authId has been set. Please call \`auth\`]`;

--- a/packages/node/src/auth-details.ts
+++ b/packages/node/src/auth-details.ts
@@ -1,0 +1,116 @@
+export class TokenData {
+  public readonly active: boolean
+  public readonly clientID: string
+  public readonly expiresAt?: Date
+  public readonly issuedAt: Date
+  public readonly scopes?: string[]
+  public readonly tokenType: TokenType
+  public readonly value: string
+
+  constructor(rawData: TokenRawData) {
+    const expectScopes = rawData.token_type === 'bearer' || rawData.token_type === 'refresh'
+
+    this.active = rawData.active
+    this.clientID = rawData.client_id
+    this.expiresAt = rawData.exp ? new Date(rawData.exp * 1000) : undefined
+    this.issuedAt = new Date(rawData.iat * 1000)
+    this.scopes = rawData.scope ? rawData.scope.split(' ') : expectScopes ? [] : undefined
+    this.tokenType = rawData.token_type
+    this.value = rawData.value
+  }
+}
+
+const pick = <T, K extends keyof T>(object: T, ...keys: K[]): Pick<T, K> => {
+  const result: any = {}
+
+  for (const key of keys) {
+    const value = object[key]
+
+    if (value !== undefined) {
+      result[key] = object[key]
+    }
+  }
+
+  return result
+}
+
+export const translateAuthDetails = (rawData: any) => {
+  const authDetails: TotalAuthDetails = pick(
+    rawData,
+    'callbackParams',
+    'clientID',
+    'clientSecret',
+    'consumerKey',
+    'consumerSecret',
+    'idTokenJwt',
+    'tokenResponse',
+    'tokenSecret',
+    'signatureMethod'
+  )
+
+  if (rawData.idToken) {
+    authDetails.idToken = new TokenData(rawData.idToken)
+  }
+
+  if (rawData.refreshToken) {
+    authDetails.refreshToken = new TokenData(rawData.refreshToken)
+  }
+
+  return {
+    ...authDetails,
+    rawData,
+    accessToken: new TokenData(rawData.accessToken)
+  } as AuthDetails
+}
+
+export enum TokenType {
+  OAuth1 = 'oauth',
+  OAuth2AccessToken = 'bearer',
+  OAuth2RefreshToken = 'refresh', // Not defined in RFC7662
+  OpenIDConnect = 'id' // Not defined in RFC7662
+}
+
+type TokenRawData = {
+  active: boolean
+  client_id: string
+  exp?: number
+  iat: number
+  scope?: string
+  token_type: TokenType
+  value: string
+}
+
+interface AuthDetailsBase {
+  callbackParams: Record<string, string>
+  rawData: any
+  tokenResponse: {
+    body: any
+    headers: Record<string, string>
+  }
+}
+
+export enum OAuth1SignatureMethod {
+  HmacSha1 = 'HMAC-SHA1',
+  RsaSha1 = 'RSA-SHA1',
+  PlainText = 'PLAINTEXT'
+}
+
+export interface OAuth1AuthDetails extends AuthDetailsBase {
+  consumerKey: string
+  consumerSecret: string
+  signatureMethod: OAuth1SignatureMethod
+  tokenSecret: string
+  accessToken: TokenData
+}
+
+export interface OAuth2AuthDetails extends AuthDetailsBase {
+  clientID: string
+  clientSecret: string
+  idTokenJwt?: any
+  accessToken: TokenData
+  idToken?: TokenData
+  refreshToken?: TokenData
+}
+
+export type AuthDetails = OAuth1AuthDetails | OAuth2AuthDetails
+type TotalAuthDetails = Partial<OAuth1AuthDetails & OAuth2AuthDetails>


### PR DESCRIPTION

## 🐻 What your PR is doing?

For the Node client, adds `api.getAuth()` to retrieve auth details. We wrap the raw response from the fetch auth endpoint to decode the dates and give more user-friendly/idiomatic names to the returned values.

## 📦 Package concerned

- @bearer/node

## ✅ Checklist

- [x] Tests were added (if necessary)
- [x] I used conventional commits
